### PR TITLE
Require C++11 Via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(VALHALLA)
 
 INCLUDE (FindPackageHandleStandardArgs)
@@ -11,7 +11,9 @@ option(BUILD_HSABolt "Build the HSA Bolt files" OFF)
 option(BUILD_TBB "Build the TBB files" OFF)
 
 
-ADD_DEFINITIONS("-std=c++11")
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD_REQUIRED)
+
 INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if (${BUILD_ArrayFire})

--- a/include/valhalla.hpp
+++ b/include/valhalla.hpp
@@ -3,11 +3,6 @@
 #include <iomanip>
 #include <cstdio>
 #include <stdexcept>
-
-#if __cplusplus <= 199711L
-    #error "C++11 support is required"
-#endif
-
 #include <chrono>
 
 namespace vll


### PR DESCRIPTION
Instead of checking the `__cplusplus` macro, it's probably more portable to enfore this requirement for C++11 via CMake. Note this requires a minimum CMake version of 3.0.

This was the only issue I ran into when testing on Windows with Visual Studio 2017 (15.8.3). 